### PR TITLE
Improve error handling for recent searches in localStorage

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,5 +1,3 @@
-
-
 const form = document.getElementById('weather-form');
 const cityInput = document.getElementById('city');
 const weatherData = document.getElementById('weather-data');
@@ -155,15 +153,36 @@ function isLocalStorageAvailable() {
 }
 
 function addToRecentSearches(city) {
-    if (isLocalStorageAvailable()) {
-        let recent = JSON.parse(localStorage.getItem('recentSearches')) || [];
-        recent = [city, ...recent.filter(c => c !== city)].slice(0, 5);
-        localStorage.setItem('recentSearches', JSON.stringify(recent));
-    } else {
-        recentSearches = [city, ...recentSearches.filter(c => c !== city)].slice(0, 5);
+    try {
+        if (isLocalStorageAvailable()) {
+            let recent = JSON.parse(localStorage.getItem('recentSearches')) || [];
+
+            recent = [city, ...recent.filter(c => c !== city)].slice(0, 5);
+
+            localStorage.setItem('recentSearches', JSON.stringify(recent));
+        } else {
+            recentSearches = [city, ...recentSearches.filter(c => c !== city)].slice(0, 5);
+        }
+    } catch (error) {
+        if (error.name === 'QuotaExceededError') {
+            console.warn('LocalStorage quota exceeded. Removing oldest search.');
+
+            let recent = JSON.parse(localStorage.getItem('recentSearches')) || [];
+            recent.pop();
+
+            try {
+                localStorage.setItem('recentSearches', JSON.stringify(recent));
+            } catch (retryError) {
+                console.error('Still failing after removing oldest entry:', retryError);
+            }
+        } else {
+            console.error('Error adding to recent searches:', error);
+        }
     }
+
     displayRecentSearches();
 }
+
 
 function displayRecentSearches() {
     const recent = isLocalStorageAvailable()


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Improve error handling for recent searches in localStorage

Closes #59 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->
This pull request includes changes to the `public/script.js` file to enhance the handling of recent searches and improve error handling when interacting with localStorage. The most important changes include adding error handling to the `addToRecentSearches` function to manage quota exceeded errors and other potential issues.

Error handling improvements:

* [`public/script.js`](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R156-R186): Added a `try-catch` block in the `addToRecentSearches` function to handle errors when accessing localStorage, specifically addressing `QuotaExceededError` by removing the oldest search entry and retrying.

