### PR TITLE
Normalize city names in recent searches and update storage logic

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -162,12 +162,17 @@ function isLocalStorageAvailable() {
 }
 
 function addToRecentSearches(city) {
+    const normalizedCity = city.trim().toLowerCase(); // Normalize to lowercase
     if (isLocalStorageAvailable()) {
         let recent = JSON.parse(localStorage.getItem('recentSearches')) || [];
-        recent = [city, ...recent.filter(c => c !== city)].slice(0, 5);
+        recent = recent.filter(c => c.toLowerCase() !== normalizedCity);
+        recent = [city, ...recent].slice(0, 5);
         localStorage.setItem('recentSearches', JSON.stringify(recent));
     } else {
-        recentSearches = [city, ...recentSearches.filter(c => c !== city)].slice(0, 5);
+        recentSearches = recentSearches
+            .filter(c => c.toLowerCase() !== normalizedCity)
+            .slice(0, 4);
+        recentSearches.unshift(city);
     }
     displayRecentSearches();
 }


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : fix Recent Searches Treat City Names Case-Sensitively

Closes #58 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->
This pull request includes changes to the `public/script.js` file to improve the handling of recent searches by normalizing city names to lowercase and ensuring consistent behavior whether or not local storage is available.

Improvements to recent searches handling:

* [`public/script.js`](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R165-R175): Normalized city names to lowercase to avoid duplicates with different cases when adding to recent searches.
* [`public/script.js`](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R165-R175): Updated the logic to handle recent searches more consistently by ensuring the new city is always added to the beginning of the list and the list is trimmed to the correct length.



