### PR TITLE
Improve city validation regex to better handle special characters

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,8 +116,7 @@ const sanitizeInput = (str) => xss(str.trim());
 
 // Enhanced city validation to support special characters
 const isValidCity = (city) => {
-  // Updated regex to better handle apostrophes and special characters
-  return /^[a-zA-Z\s'-]{2,50}$/.test(city) || /^[\p{L}\s'-]{2,50}$/u.test(city);
+  return /^[\p{L}\p{M}\s'’-]{2,50}$/u.test(city);
 };
 
 // Function to parse temperature with sanity check


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Improve city validation regex to better handle special characters

Closes #76 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->

### **Updated `isValidCity` Function**
We should use Unicode property escapes (`\p{L}`) to match letters from all languages, including accented characters, Cyrillic, Arabic, Chinese, etc. Here's the improved version:

```js
const isValidCity = (city) => {
  return /^[\p{L}\p{M}\s'’-]{2,50}$/u.test(city);
};
```

### **Changes & Enhancements:**
1. **`\p{L}`** → Matches any letter from any language.
2. **`\p{M}`** → Allows combining diacritical marks (like accents, tildes).
3. **`\s`** → Allows spaces between words.
4. **`'’-`** → Supports apostrophes and both hyphen (`-`) & en-dash (`’`).
5. **`/u`** → Enables Unicode mode for proper multi-language support.
6. **`{2,50}`** → Ensures city names have a reasonable length (2 to 50 characters).

### **Examples of Supported City Names:**
✅ `São Paulo`  
✅ `München`  
✅ `Beijing`  
✅ `New York`  
✅ `Saint-Denis`  
✅ `東京` (Tokyo in Japanese)  
✅ `Київ` (Kyiv in Ukrainian)  


