### PR TITLE
✅ Improved city name validation with clear error messaging (Fixes #164)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -38,32 +38,39 @@ function initialize() {
     loadConfig();
 }
 
+
 async function handleSubmit(e) {
     e.preventDefault();
     const city = cityInput.value.trim();
 
-    // Clear the previous error message when a new search starts
     clearError();
 
+    // ✅ Empty check
+    if (city === '') {
+        showError('City name cannot be empty.');
+        return;
+    }
+
+    // ✅ City format validation
     if (!isValidInput(city)) {
-      
-        showError('Please enter a valid city name (e.g., São Paulo, O\'Fallon).');
+        showError('❌ Invalid city name. Only letters, spaces, apostrophes, periods, and hyphens are allowed.');
         return;
     }
 
     try {
         toggleLoading(true);
         const data = await fetchWeatherData(city);
-        
+
         displayWeather(data);
         addToRecentSearches(city);
     } catch (error) {
-        console.log(error)
+        console.error(error);
         showError(error.message);
     } finally {
         toggleLoading(false);
     }
 }
+
 
 async function fetchWeatherData(city) {
     try {


### PR DESCRIPTION

<img width="882" height="522" alt="improved validation " src="https://github.com/user-attachments/assets/9589a4da-2baa-49fe-bf8f-80c046ffb775" />
### 🔧 Fix: Added Basic City Name Validation (Fixes #164)

#### ✨ What’s Improved:<img width="882" height="522" alt="improved validation " src="https://github.com/user-attachments/assets/a8f37d3f-f6d6-4aed-961b-6832d02699c0" />- Basic input validation for the city name field.
- The app checks if the input is valid before making an API call.
- Shows an error message for empty or invalid inputs.

#### 📌 Why it matters:
- Avoids unnecessary API errors.
- Enhances user experience with better feedback and input control.

#### 🧪 Example cases:
- ✅ `London` → valid
- ❌ `123Paris` → invalid
- ❌ `@Delhi!` → invalid
- ❌ (empty input) → error message shown
