### PR TITLE
fix: add aria-label to clear button for accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,7 +53,7 @@
           <span class="button-text">Get Weather</span>
           <div class="spinner hidden" aria-hidden="true"></div>
         </button>
-        <button type="button" id="clear-btn">
+        <button type="button" id="clear-btn" aria-label="Clear search">
           <span class="button-text">CLEAR</span>
           <div class="clr-spinner hidden" aria-hidden="true"></div>
         </button>


### PR DESCRIPTION
# PULL REQUEST

Title: fix: Add aria-label to clear button for accessibility

Closes #196

# 📌 Description

Added an `aria-label` attribute to the clear button in the search form to improve accessibility for screen reader users. This change ensures that users with visual impairments can understand the purpose of the clear button.

# 📷 Screenshots

<!-- No visual changes, only accessibility improvements -->

**Additional context**
- Added `aria-label="Clear search"` to the clear button
- Follows WCAG accessibility guidelines
- No breaking changes introduced

# 🏆 Are you contributing under any open-source program?
No, contributing independently.