### PR TITLE
Remove unused response.clone in service worker fetch handler

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -59,7 +59,6 @@ self.addEventListener("fetch", (event) => {
         if (cached) return cached;
 
         return fetch(event.request).then((response) => {
-          const clonedResponse = response.clone();
           if (
             event.request.method === "GET" &&
             response.status === 200 &&


### PR DESCRIPTION
Title :Remove unused response.clone in service worker fetch handler

Closes #293 


# 📌 Description

Removes an unnecessary response.clone() in the service worker’s fetch event handler (sw.js). The first clone was never used, which caused minor inefficiency and reduced code clarity.

Details:

Only the clone used for caching is kept.
No functional changes; performance and readability improvement.

