### PR TITLE
fix(security): enforce static JWT_SECRET and fail fast if missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .env
 .vscode/
 logs
+
+.DS_Store

--- a/src/config/oauth.js
+++ b/src/config/oauth.js
@@ -1,9 +1,12 @@
-const crypto = require("crypto");
+// Fail fast if JWT_SECRET is missing
+if (!process.env.JWT_SECRET) {
+  throw new Error("FATAL: JWT_SECRET is not set in environment variables.");
+}
 
 const oauthConfig = {
   // JWT Configuration
   jwt: {
-    secret: process.env.JWT_SECRET || crypto.randomBytes(64).toString("hex"),
+    secret: process.env.JWT_SECRET,
     accessTokenExpiry: parseInt(process.env.JWT_ACCESS_TOKEN_EXPIRY) || 3600, // 1 hour
     refreshTokenExpiry:
       parseInt(process.env.JWT_REFRESH_TOKEN_EXPIRY) || 604800, // 7 days


### PR DESCRIPTION
### Summary
Previously, the OAuth configuration generated a random JWT secret at startup
when JWT_SECRET was not set. This caused all existing tokens to become invalid
after every server restart and made token verification impossible across
multiple instances.

This commit removes the insecure fallback and introduces a fail-fast
initialization check in `src/config/oauth.js`. The application will now
explicitly throw an error if JWT_SECRET is missing, ensuring stable and
predictable token validation across environments.

### Changes:
- Removed randomBytes fallback for JWT secret.
- Added startup validation to throw an error if JWT_SECRET is not set.
- Ensured consistent configuration loading across all OAuthService instances.

### Security impact:
✅ Prevents session invalidation after restarts.
✅ Ensures consistent JWT validation across distributed systems.
✅ Improves configuration reliability in production.

### BREAKING CHANGE:
Applications must now define a valid JWT_SECRET environment variable.

### Related PRs
Closes #291 